### PR TITLE
Initial home page state shows data for most recent year

### DIFF
--- a/.ebextensions/00_change_npm_permissions.config
+++ b/.ebextensions/00_change_npm_permissions.config
@@ -1,8 +1,0 @@
-files:
-  "/opt/elasticbeanstalk/hooks/appdeploy/post/00_set_tmp_permissions.sh":
-    mode: "000755"
-    owner: root
-    group: root
-    content: |
-      #!/usr/bin/env bash
-      chown -R nodejs:nodejs /tmp/.npm

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,14 @@ branches:
   only:
   - master
 deploy:
-  provider: elasticbeanstalk
+  provider: s3
   access_key_id: ${AWS_ACCESS_KEY_ID}
   secret_access_key: ${AWS_SECRET_ACCESS_KEY}
-  region: us-east-1
-  app: dbknews-elastic-beanstalk
-  env: dbknews-salaryguide
-  bucket_name: salaryguide.dbknews.com
+  bucket: salaryguide.dbknews.com
+  acl: public_read
+  local_dir: build
+  skip_cleanup: true
   on:
     branch: master
 after_deploy:
-  - echo "Application Deployed!"
+  - echo "Static site deployed"

--- a/package-lock.json
+++ b/package-lock.json
@@ -910,9 +910,9 @@
       "integrity": "sha512-1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA=="
     },
     "@hapi/hoek": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.0.tgz",
-      "integrity": "sha512-7XYT10CZfPsH7j9F1Jmg1+d0ezOux2oM2GfArAzLwWe4mE2Dr3hVjsAL6+TFY49RRJlCdJDMw3nJsLFroTc8Kw=="
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.1.tgz",
+      "integrity": "sha512-yN7kbciD87WzLGc5539Tn0sApjyiGHAJgKvG9W8C7O+6c7qmoQMfVs0W4bX17eqz6C78QJqqFrtgdK5EWf6Qow=="
     },
     "@hapi/joi": {
       "version": "15.1.1",

--- a/src/components/organisms/Guide.jsx
+++ b/src/components/organisms/Guide.jsx
@@ -233,35 +233,33 @@ export default class Guide extends Component {
   }
 
   handle_search = () => {
-    let term = $("#search-box").val().trim()
-    this.handle_params("search", term)
+    let term = $('#search-box').val().trim()
+    this.handle_params('search', term)
   }
 
   handle_key_press = e => {
     if (e.keyCode === 37) {
       this.handle_button('previous')
-    }
-    else if (e.keyCode === 39) {
+    } else if (e.keyCode === 39) {
       this.handle_button('next')
-    }
-    else if (e.keyCode == 13) {
+    } else if (e.keyCode === 13) {
       this.handle_search()
     }
   }
 
   disable_inputs = () => {
-    console.log("disabling inputs")
-    $("select").prop('disabled', true)
-    $("#btn-back").prop('disabled', true)
-    $("#btn-next").prop('disabled', true)
-    $("input").prop('disabled', true)
+    console.log('disabling inputs')
+    $('select').prop('disabled', true)
+    $('#btn-back').prop('disabled', true)
+    $('#btn-next').prop('disabled', true)
+    $('input').prop('disabled', true)
   }
-  
+
   enable_inputs = () => {
-    console.log("enabling inputs")
-    $("select").prop('disabled', false)
-    $("#btn-back").prop('disabled', false)
-    $("#btn-next").prop('disabled', false)
-    $("input").prop('disabled', false)
+    console.log('enabling inputs')
+    $('select').prop('disabled', false)
+    $('#btn-back').prop('disabled', false)
+    $('#btn-next').prop('disabled', false)
+    $('input').prop('disabled', false)
   }
 }

--- a/src/components/organisms/Guide.jsx
+++ b/src/components/organisms/Guide.jsx
@@ -43,8 +43,7 @@ export default class Guide extends Component {
     loading: true,
     params: {
       search: '', sortby: 'salary', order: 'desc', page: '1'
-    },
-    url: '/year/2019'
+    }
   }
 
   /**
@@ -139,8 +138,15 @@ export default class Guide extends Component {
     try {
       console.group('Getting Salary Guide data...')
 
+      // Get all years and select the most recent one (aka largest)
+      let yearReq = await request({ url: '/years', method: 'get' })
+      let yearNums = yearReq.data.data.map(yearString => Number.parseInt(yearString))
+      yearNums.sort()
+      let mostRecentYear = yearNums[yearNums.length - 1]
+
       // Get table data based on current state
-      const { url, params } = this.state
+      const { params } = this.state
+      let url = `/year/${mostRecentYear}`
       let req = await request({ url: url, params: params, method: 'get' })
 
       console.info('Retreived Salary Guide data ->', req.data)

--- a/src/components/organisms/Guide.jsx
+++ b/src/components/organisms/Guide.jsx
@@ -146,7 +146,9 @@ export default class Guide extends Component {
 
       // Get table data based on current state
       const { params } = this.state
-      let url = `/year/${mostRecentYear}`
+      // Base url is either most recent year or whatever the state's url is
+      // State's url can be modified from search parameters/filters
+      let url = this.state.url || `/year/${mostRecentYear}`
       let req = await request({ url: url, params: params, method: 'get' })
 
       console.info('Retreived Salary Guide data ->', req.data)
@@ -209,6 +211,8 @@ export default class Guide extends Component {
     if (type !== 'page') {
       params_copy['page'] = '1'
     }
+
+    console.log(params_copy)
 
     this.setState(
       state => ({ ...state, params: params_copy }),

--- a/src/components/organisms/Header.jsx
+++ b/src/components/organisms/Header.jsx
@@ -10,7 +10,6 @@ import { Link } from '../atoms'
 import { HeaderNavigation } from '../molecules'
 import Filter from './Filter.jsx'
 
-
 /**
  * @file Preact component representing the header.
  * @author Lexus Drumgold <lex@lexusdrumgold.design>


### PR DESCRIPTION
Previously, initial state's url was hard-coded to `/year/2019`. This poses a few issues when salary data for new years are uploaded:
1. Maintainers have to manually change the initial state's url to the most recent year. While it's a simple fix, it can and should be avoided
2. The "years" filter drop-down will show 2020, but will actually display 2019 data; very misleading. This can be fixed by changing the year to something else (say 2018) and then back to 2020.

This PR solves both of these issues. In `Guide#get_data`, we request all years available from the `/years` endpoint, and select the most recent year. From there, the request we make depends on `state.url`. We use `state.url` if it's defined and non-null. Otherwise, we fall back to using the base url `/year/{mostRecentYear}`. By preferring to use `state.url` when possible, we give priority to the user's actions and wants (i.e. they want year 2015 with an ascending parameter).